### PR TITLE
Remove unload from main.

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -9,15 +9,6 @@ if (environment === 'development') {
 let de = new DesktopEnvironment();
 window.desktopEnvironment = de;
 
-// Clean up when the page is unloaded (onunload is deprecated, but still works in all browsers)
-window.onunload = () => {
-    if (de) {
-        de.destroy();
-    }
-};
-
-let windowManager = de.windowManager;
-
 /*
   Do not commit changes below this, we'll have this for testing only to start apps
   we're currently working on etc. 

--- a/assets/js/modules/Desktop.js
+++ b/assets/js/modules/Desktop.js
@@ -40,7 +40,7 @@ export default class Desktop {
                     break;
             }
         } catch (e) {
-            console.log("Error reading desktop settings");
+            console.log("[desktop] failed to load desktop settings, this is likely because no settings have been saved yet.");
         }
 
         this.render();

--- a/assets/js/modules/DesktopEnvironment.js
+++ b/assets/js/modules/DesktopEnvironment.js
@@ -60,7 +60,7 @@ export default class DesktopEnvironment {
         // Example: Alt+Tab window switching
         if (event.altKey && event.key === 'Tab') {
             event.preventDefault();
-            console.log("Alt+Tab - Cycle Windows?");
+            console.log("[desktop_env] TODO: Alt+Tab was pressed, cycle windows?");
         }
         // Example: Windows key for start menu
         if (event.key === 'Meta') {

--- a/assets/js/modules/apps/DesktopSettings.js
+++ b/assets/js/modules/apps/DesktopSettings.js
@@ -23,7 +23,7 @@ export default class DesktopSettings {
         try {
             this.currentSettings = JSON.parse(this.fs.readFile(this.filename));
         } catch (e) {
-            console.log("Error reading settings", e);
+            console.log("[desktop_settings] failed to load desktop settings, this is likely because no settings have been saved yet.");
         }
 
         this.windowObject.setTitle("Desktop Settings");
@@ -100,7 +100,7 @@ export default class DesktopSettings {
         try {
             this.fs.createDirectory('C:\\settings');
         } catch (e) {
-            console.log("Settings directory already exists");
+            console.log("[desktop_settings] settings directory already exists.");
         }
         const fileContents = JSON.stringify({
             color: this.windowContent.querySelector("#color").value,

--- a/assets/js/modules/apps/Terminal.js
+++ b/assets/js/modules/apps/Terminal.js
@@ -750,7 +750,7 @@
                     path : 
                     `${this.currentPath}\\${path}`;
 
-                console.log('[terminal] Creating directory:', fullPath);
+                console.log('[terminal] creating directory:', fullPath);
                 this.fs.createDirectory(fullPath);
             } catch (error) {
                 this.writeOutput(error.message);


### PR DESCRIPTION
This effectively kills all cleanup (it was a gimmick, if the window closes GC goes brr) so I've just removed the actual call to cleanup code.

I've not removed the actual cleanup code however, as it displays an understanding of stuff.